### PR TITLE
Add topographic universal transformer (TUT)

### DIFF
--- a/columnformers/losses.py
+++ b/columnformers/losses.py
@@ -64,6 +64,7 @@ class TVMixtureLoss(nn.Module):
         self.lambd = lambd
 
     def forward(self, batch: State, output: torch.Tensor, state: State) -> torch.Tensor:
+        # TODO: extend to handle the recurrent case
         coef = state.get("coef")
         if coef is None:
             return torch.zeros((), device=output.device, dtype=output.dtype)

--- a/columnformers/models/columnformer.py
+++ b/columnformers/models/columnformer.py
@@ -616,11 +616,12 @@ class Columnformer(nn.Module):
         self, input: torch.Tensor
     ) -> Tuple[torch.Tensor, Dict[str, torch.Tensor]]:
         x = input
-        if self.recurrent and x.shape[1] < self.seq_len:
+        if self.recurrent and input.shape[1] < self.seq_len:
             x = F.pad(x, (0, 0, 0, self.seq_len - input.shape[1]))
-
         if self.pos_embed is not None:
             x = x + self.pos_embed
+            # ensure input also pos embedded for direct edges
+            input = x[:, : input.shape[1]]
 
         skip_x = None
         states = []

--- a/columnformers/models/columnformer.py
+++ b/columnformers/models/columnformer.py
@@ -610,6 +610,9 @@ class Columnformer(nn.Module):
         # can't stack coefficients because they may have different shapes
         for key in ["attn", "features"]:
             state[key] = torch.stack(state[key], dim=1)
+
+        if self.recurrent and "coef" in state:
+            state["coef"] = state["coef"][:1]
         return x, state
 
     def extra_repr(self) -> str:

--- a/columnformers/models/geometry.py
+++ b/columnformers/models/geometry.py
@@ -1,21 +1,25 @@
-from typing import Tuple
+from collections.abc import Sequence
+from typing import Union
 
 import torch
 
 
 def multilayer_geometry(
-    widths: Tuple[int, ...], depth_offset: float = 2.0
+    widths: Union[int, Sequence[int]], depth_offset: float = 2.0
 ) -> torch.Tensor:
     """
     Construct a 3D geometry for a stack of square layers.
 
     Args:
-        widths: tuple of layer widths
+        widths: sequence of layer widths or single layer width
         depth_offset: distance between layers
 
     Returns:
         dist, shape (N, N)
     """
+    if not isinstance(widths, Sequence):
+        widths = [widths]
+
     layers = []
     for ii, width in enumerate(widths):
         points = torch.linspace(-width / 2, width / 2, width)

--- a/columnformers/models/layers.py
+++ b/columnformers/models/layers.py
@@ -191,6 +191,52 @@ class UntiedLayerNorm(nn.Module):
         )
 
 
+class MixtureLayerNorm(nn.Module):
+    def __init__(
+        self,
+        dim: int,
+        coef: "MixtureCoefficients",
+        eps: float = 1e-5,
+        elementwise_affine: bool = True,
+    ):
+        super().__init__()
+        self.dim = dim
+        self.eps = eps
+        self.elementwise_affine = elementwise_affine
+        self.coef = coef
+
+        if self.elementwise_affine:
+            self.weight = nn.Parameter(torch.empty(dim, coef.rank))
+            self.bias = nn.Parameter(torch.empty(dim, coef.rank))
+        else:
+            self.register_parameter("weight", None)
+            self.register_parameter("bias", None)
+        self.reset_parameters()
+
+    def reset_parameters(self) -> None:
+        if self.elementwise_affine:
+            nn.init.ones_(self.weight)
+            nn.init.zeros_(self.bias)
+
+    def forward(self, input: torch.Tensor) -> torch.Tensor:
+        input = F.layer_norm(input, (self.dim,), eps=self.eps)
+        if self.elementwise_affine:
+            coef = self.coef()
+            weight = coef @ self.weight.t()
+            bias = coef @ self.bias.t()
+            input = input * weight + bias
+        return input
+
+    def no_weight_decay(self) -> List[str]:
+        # Nb, not excluded by default since 2d
+        return ["weight", "bias"]
+
+    def extra_repr(self) -> str:
+        return (
+            f"{self.dim}, eps={self.eps}, elementwise_affine={self.elementwise_affine}"
+        )
+
+
 class SpatialPool(nn.Module):
     """
     Pool a sequence of features with a learned attention weight per class.

--- a/columnformers/models/vision_columnformer.py
+++ b/columnformers/models/vision_columnformer.py
@@ -249,3 +249,34 @@ def vision_columnformer_r_tiny_patch16_128(**kwargs):
         **kwargs,
     )
     return model
+
+
+@register_model
+def vision_tut_tiny_patch16_128(**kwargs):
+    encoder_params = {
+        "embed_dim": 384,
+        "depth": 6,
+        "recurrent": True,
+        "seq_len": 384,
+    }
+    encoder_defaults = {
+        "attn_mode": "classic",
+        "mlp_mode": "moe",
+        "norm_mode": "classic",
+        "num_heads": 6,
+        "mlp_ratio": 1.0,
+        "moe_experts": 24,
+        "moe_conserve": False,
+        "attn_bias": True,
+    }
+    params = {"img_size": 128, "patch_size": 16}
+    defaults = {}
+    model = _create_vision_columnformer(
+        widths=6 * (8,),
+        encoder_params=encoder_params,
+        encoder_defaults=encoder_defaults,
+        params=params,
+        defaults=defaults,
+        **kwargs,
+    )
+    return model

--- a/columnformers/models/vision_columnformer.py
+++ b/columnformers/models/vision_columnformer.py
@@ -260,14 +260,14 @@ def vision_tut_tiny_patch16_128(**kwargs):
 
 
 @register_model
-def vision_tut_res_tiny_patch16_128(**kwargs):
+def vision_tut_ff_tiny_patch16_128(**kwargs):
     encoder_params = {
         "embed_dim": 384,
         "depth": 6,
         "recurrent": True,
         "seq_len": 384,
         "geometry": multilayer_geometry(6 * (8,)),
-        # Direct connections from previous layer to the mlp (skipping attention).
+        # Direct connections to each layer.
         # Note that these indices are into `cat([input, x], dim=1)`, so the first layer
         # gets input, second layer gets first layer output, etc.
         "direct_edges": torch.arange(384),

--- a/columnformers/train.py
+++ b/columnformers/train.py
@@ -118,6 +118,9 @@ class Args:
     pos_embed: Optional[bool] = HfArg(
         aliases=["--pos"], default=None, help="use position embedding"
     )
+    time_embed: Optional[bool] = HfArg(
+        aliases=["--time_embed"], default=None, help="use time embedding"
+    )
     drop_rate: float = HfArg(aliases=["--dr"], default=0.0, help="head dropout rate")
     proj_drop_rate: float = HfArg(
         aliases=["--pdr"], default=0.0, help="projection dropout rate"
@@ -340,6 +343,7 @@ def main(args: Args):
         num_classes=num_classes,
         global_pool=args.global_pool,
         pos_embed=args.pos_embed,
+        time_embed=args.time_embed,
         drop_rate=args.drop_rate,
         proj_drop_rate=args.proj_drop_rate,
         attn_drop_rate=args.attn_drop_rate,

--- a/columnformers/train.py
+++ b/columnformers/train.py
@@ -101,8 +101,8 @@ class Args:
         help="number of experts for MoE MLP. can be a single value or a list of values, "
         "e.g. '2', '1,1,2,2,4,4'",
     )
-    moe_conserve: bool = HfArg(
-        default=True,
+    moe_conserve: Optional[bool] = HfArg(
+        default=None,
         help="Divide params by num experts "
         "`expert_params = dim * mlp_ratio / num_experts`",
     )

--- a/columnformers/utils/misc.py
+++ b/columnformers/utils/misc.py
@@ -148,7 +148,8 @@ def filter_kwargs(func: Callable, kwargs: Dict[str, Any]):
     """
     Filter unused extra kwargs. Returns filtered kwargs and a list of extra args.
     """
-    allowed_args = set(inspect.getfullargspec(func).args)
+    spec = inspect.getfullargspec(func)
+    allowed_args = set(spec.args + spec.kwonlyargs)
     extra_args = []
     kwargs = kwargs.copy()
     for k in list(kwargs):

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,9 +4,10 @@ matplotlib==3.8.2
 numpy==1.26.2
 Pillow==10.1.0
 timm==0.9.12
-torch==2.1.1
-torchvision==0.16.1
+torch==2.3.0
+torchvision==0.18.0
 transformers==4.36.2
+triton==2.3.0
 wandb==0.16.2
 
 ipython==8.18.0

--- a/tests/test_models/test_vision_columnformer.py
+++ b/tests/test_models/test_vision_columnformer.py
@@ -16,6 +16,7 @@ from columnformers.models.vision_columnformer import VisionColumnformer
         "vision_columnformer_ff_tiny_patch16_128",
         "vision_columnformer_r_tiny_patch16_128",
         "vision_tut_tiny_patch16_128",
+        "vision_tut_res_tiny_patch16_128",
     ],
 )
 @pytest.mark.parametrize("global_pool", ["avg", "spatial"])

--- a/tests/test_models/test_vision_columnformer.py
+++ b/tests/test_models/test_vision_columnformer.py
@@ -17,6 +17,7 @@ from columnformers.models.vision_columnformer import VisionColumnformer
         "vision_columnformer_r_tiny_patch16_128",
         "vision_tut_tiny_patch16_128",
         "vision_tut_ff_tiny_patch16_128",
+        "vision_transformer_r_tiny_patch16_128",
     ],
 )
 @pytest.mark.parametrize("global_pool", ["avg", "spatial"])

--- a/tests/test_models/test_vision_columnformer.py
+++ b/tests/test_models/test_vision_columnformer.py
@@ -16,7 +16,7 @@ from columnformers.models.vision_columnformer import VisionColumnformer
         "vision_columnformer_ff_tiny_patch16_128",
         "vision_columnformer_r_tiny_patch16_128",
         "vision_tut_tiny_patch16_128",
-        "vision_tut_res_tiny_patch16_128",
+        "vision_tut_ff_tiny_patch16_128",
     ],
 )
 @pytest.mark.parametrize("global_pool", ["avg", "spatial"])

--- a/tests/test_models/test_vision_columnformer.py
+++ b/tests/test_models/test_vision_columnformer.py
@@ -15,6 +15,7 @@ from columnformers.models.vision_columnformer import VisionColumnformer
         "vision_moemixer_tiny_patch16_128",
         "vision_columnformer_ff_tiny_patch16_128",
         "vision_columnformer_r_tiny_patch16_128",
+        "vision_tut_tiny_patch16_128",
     ],
 )
 @pytest.mark.parametrize("global_pool", ["avg", "spatial"])

--- a/tests/test_train.py
+++ b/tests/test_train.py
@@ -60,7 +60,8 @@ configs = {
     "tut": train.Args(
         model="vision_tut_tiny_patch16_128",
         dataset="debug-100",
-        moe_experts="24",
+        moe_experts="12",
+        mlp_ratio=2.0,
         wiring_lambd=0.1,
         workers=0,
         batch_size=32,

--- a/tests/test_train.py
+++ b/tests/test_train.py
@@ -57,6 +57,18 @@ configs = {
         overwrite=True,
         debug=True,
     ),
+    "tut": train.Args(
+        model="vision_tut_tiny_patch16_128",
+        dataset="debug-100",
+        moe_experts="24",
+        wiring_lambd=0.1,
+        workers=0,
+        batch_size=32,
+        out_dir="test_results",
+        name="debug_train_tut",
+        overwrite=True,
+        debug=True,
+    ),
 }
 
 
@@ -68,6 +80,7 @@ configs = {
         "recurrent",
         "wiring",
         "moe",
+        "tut",
     ],
 )
 def test_train(config: str):


### PR DESCRIPTION
The [Universal Transformer (UT)](https://arxiv.org/abs/1807.03819) architecture adds recurrence to the classic transformer by way of depth-wise weight sharing. More recently, the [Sparse Universal Transformer (SUT)](https://arxiv.org/abs/2310.07096) combines the UT with sparse mixture of experts, resulting in depth-wise weight sharing, and horizontal weight differentiation, much like our idea for the recurrent columnformer.

<img width="268" alt="Screenshot 2024-05-03 at 9 15 03 AM" src="https://github.com/clane9/columnformers/assets/11963692/e087389d-8838-4515-9c63-080dc65a654e">

Here we add the Topographic Universal Transformer (TUT), which combines the UT with topographic mixture of experts (#5). The network consists of a sheet of transformer modules ("columns"), applied to the input recursively as in UT. The MLP at each position in the sheet is assigned weights from a pool of experts by way of a softmax weighted combination using static learned coefficients. The self-attention is as of now unchanged wrt to the UT, meaning in particular the weights are shared across depth and width.